### PR TITLE
Feature document reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ yt --transcript https://youtube.com/watch?v=uXs-zPc63kM | fabric --stream --patt
 pbpaste | analyze_claims --stream
 ```
 
-5. **new** Extract pdfs contents directly into your pattern
+5. **new** Extract document contents directly into your pattern
 
 ```bash
 pe filename | fabrich -p extract_wisdom 

--- a/installer/client/cli/pe.py
+++ b/installer/client/cli/pe.py
@@ -2,22 +2,27 @@ import pymupdf
 import argparse
 import pymupdf4llm
 import pathlib
+import os
 
 def main():
     parser = argparse.ArgumentParser()
     parser = argparse.ArgumentParser(
-        description='pdfExtractor extracts all the text from a pdf. By Fabian Wieland.')
+        description='This Module extracts all the text from a documents. By Fabian Wieland.')
     parser.add_argument('filename')
     parser.add_argument("-p", "--page", help='Select a specific page to extract')
     parser.add_argument("-m",'--markdown', action='store_true', help='Retrieve your document content in Markdown')
     parser.add_argument("-s",'--save', action='store_true', help='Saves markdownfile (created with -m) utf-8 encoded as output.md')
-    args = parser.parse_args()
-    if args.filename is None:
-        print("Error: No file provided.")
-        return
-    extract_content(args.filename, args)
    
+    args = parser.parse_args()
 
+    if os.path.isfile(args.filename):
+        print(extract_content(args.filename, args))
+    elif os.path.isdir(args.filename):
+        print(extract_multi_file(args.filename,args))
+    else:
+        print("Error: No valid file or folder provided. Please provide a valid file or folder")
+
+  
 
 def extract_content(filename,options):
     doc = pymupdf.open(filename)  
@@ -25,20 +30,30 @@ def extract_content(filename,options):
     text=""
     if options.page:
         try:
-         print(doc.get_page_text(options))
+         return doc.get_page_text(options.page)
         except:
-         print("Error: {} is not a page in the provided document".format(options)) 
-    if (options.markdown):
+         print("Error: {} is not a page in the provided document".format(options.page)) 
+    elif (options.markdown):
         md_text = pymupdf4llm.to_markdown(filename)
         if(options.save):
             # Write the text to some file in UTF8-encoding
             pathlib.Path("output.md").write_bytes(md_text.encode())
-        print(md_text)
+        return md_text
     else:
         for page in doc:
             text+=page.get_text()
-        print(md_text)
+        return text
         
+def extract_multi_file(filename,options):
+            files = [f for f in os.listdir(filename) if os.path.isfile(os.path.join(filename,f))]
+            text=''
+            print(os.listdir(filename))
+            for f in files:
+                print(f)
+                doc = pymupdf.open(os.path.join(filename,f))  
+                for page in doc:
+                        text+=page.get_text()
+            return text
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add a pdf extractor script to directly pipe pdfs into patterns. This script is integrated into the pipx setup and can be called via "pe filename" in bash as shown in the readme.

pe filename | fabric -p extract_wisdom 
Currently only basic extraction is functional
Increased functionallity with markdown extraction from documents and saving of the markdown if wished (Flags: -m for markdown and -s to save created markdown. If no flag is set extraction happens without markdown).

pe filename -m | fabric -p extract_wisdom 
![image](https://github.com/WielandF/fabric/assets/13366088/3e34d4b5-bc2f-4ed5-9394-15406497b80d)
